### PR TITLE
fix: correct binary name

### DIFF
--- a/docs/adr/0001-simple-module-structure-over-ddd.md
+++ b/docs/adr/0001-simple-module-structure-over-ddd.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-We are building `@rindrics/repo-setup`, a CLI tool that generates project scaffolding with:
+We are building `@rindrics/initrepo`, a CLI tool that generates project scaffolding with:
 
 - CI/CD workflows (test, lint, tagpr, release)
 - husky configuration

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "setup GitHub repo with dev tools",
   "type": "module",
   "bin": {
-    "repo-setup": "./dist/cli.js"
+    "initrepo": "./dist/cli.js"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI command has been renamed from repo-setup to initrepo. Users with existing scripts or workflows referencing the old command name should update them accordingly.

* **Documentation**
  * Updated documentation to reference the new CLI command name.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->